### PR TITLE
show "reloaded" message to the person running the command (currently silent)

### DIFF
--- a/src/org/aztecmc/plugins/cron/CronPlugin.java
+++ b/src/org/aztecmc/plugins/cron/CronPlugin.java
@@ -1,13 +1,15 @@
 package org.aztecmc.plugins.cron;
 
 import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.*;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 
 public class CronPlugin extends JavaPlugin {
 
@@ -55,8 +57,29 @@ public class CronPlugin extends JavaPlugin {
         bukkitRunnable.runTaskTimer(this, 0L,
                 getConfig().getLong("bukkitRunnable-poll-resolution", 20L));
     }
+    
+    public boolean onCommand​(CommandSender sender, Command command, java.lang.String label, java.lang.String[] args) {
+        if(command.getName().equalsIgnoreCase("cron")){//no other commands should be registered, but just to be sure...
+            if(args.length > 0) {
+                if(args[0].equalsIgnoreCase("reload")) {
+                    if (sender instanceof Player) {
+                        Player player = (Player) sender;
+                        if(!player.hasPermission("cron.reload"))
+                            return false;
+                    }
+                    reloadConfig();
+                    wireCrons();
+                    log("Crons reloaded");
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+    
 
     private void register() {
+        /*
         this.getCommand("cron").setExecutor((commandSender, command, label, strings) -> {
             if(strings.length > 0) {
                 if(strings[0].equalsIgnoreCase("reload")) {
@@ -72,7 +95,7 @@ public class CronPlugin extends JavaPlugin {
                 }
             }
             return false;
-        });
+        });*/
     }
 
     @Override

--- a/src/org/aztecmc/plugins/cron/CronPlugin.java
+++ b/src/org/aztecmc/plugins/cron/CronPlugin.java
@@ -57,7 +57,7 @@ public class CronPlugin extends JavaPlugin {
     }
     
     @Override
-    public boolean onCommand​(CommandSender sender, Command command, java.lang.String label, java.lang.String[] args) {
+    public boolean onCommand​(CommandSender sender, Command command, String label, String[] args) {
         if(command.getName().equalsIgnoreCase("cron")){//no other commands should be registered, but just to be sure...
             if(args.length > 0) {
                 if(args[0].equalsIgnoreCase("reload")) {

--- a/src/org/aztecmc/plugins/cron/CronPlugin.java
+++ b/src/org/aztecmc/plugins/cron/CronPlugin.java
@@ -56,6 +56,7 @@ public class CronPlugin extends JavaPlugin {
                 getConfig().getLong("bukkitRunnable-poll-resolution", 20L));
     }
     
+    @Override
     public boolean onCommand​(CommandSender sender, Command command, java.lang.String label, java.lang.String[] args) {
         if(command.getName().equalsIgnoreCase("cron")){//no other commands should be registered, but just to be sure...
             if(args.length > 0) {

--- a/src/org/aztecmc/plugins/cron/CronPlugin.java
+++ b/src/org/aztecmc/plugins/cron/CronPlugin.java
@@ -18,8 +18,6 @@ public class CronPlugin extends JavaPlugin {
     @Override
     public void onEnable() {
         this.saveDefaultConfig();
-
-        register();
         log("Plugin loaded");
 
         wireCrons();
@@ -75,27 +73,6 @@ public class CronPlugin extends JavaPlugin {
             }
         }
         return false;
-    }
-    
-
-    private void register() {
-        /*
-        this.getCommand("cron").setExecutor((commandSender, command, label, strings) -> {
-            if(strings.length > 0) {
-                if(strings[0].equalsIgnoreCase("reload")) {
-                    if (commandSender instanceof Player) {
-                        Player player = (Player)commandSender;
-                        if(!player.hasPermission("cron.reload"))
-                            return false;
-                    }
-                    reloadConfig();
-                    wireCrons();
-                    log("Crons reloaded");
-                    return true;
-                }
-            }
-            return false;
-        });*/
     }
 
     @Override

--- a/src/org/aztecmc/plugins/cron/CronPlugin.java
+++ b/src/org/aztecmc/plugins/cron/CronPlugin.java
@@ -68,7 +68,7 @@ public class CronPlugin extends JavaPlugin {
                     }
                     reloadConfig();
                     wireCrons();
-                    log("Crons reloaded");
+                    sender.sendMessage("Crons reloaded.");//if the console sent the message, this will log to console also
                     return true;
                 }
             }

--- a/src/org/aztecmc/plugins/cron/CronPlugin.java
+++ b/src/org/aztecmc/plugins/cron/CronPlugin.java
@@ -3,13 +3,13 @@ package org.aztecmc.plugins.cron;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.*;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
 
 public class CronPlugin extends JavaPlugin {
 


### PR DESCRIPTION
Dependent on PR #1 changes, handle that one first.

Changes the log line of the reload command to sender.sendMessage so that the person (or console) is notified that crons have been reloaded successfully instead of silently running [for players].

If you don't want PR #1 there is [patch-commandfeedback-base](https://github.com/NShadeIV/Cron/compare/master...crashdemons:patch-commandfeedback-base?w=1) which does the same thing on the original code.